### PR TITLE
bump version to 1.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ repositories {
 }
 
 group = "io.fuchs.gradle.classpath-collision-detector"
-version = "0.3"
+version = "1.1"
 
 gradlePlugin {
     plugins.create("classpathCollisionDetectorPlugin") {


### PR DESCRIPTION
As per as plugin is actively used, it is better to setup release version for it. Version 1.0 is related to a new code, therefore let's select version `1.1` representing the current state of the project.