### PR TITLE
Use java8 bytecode always

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,7 @@ plugins {
     id("com.gradle.plugin-publish") version "1.0.0"
 }
 
-val javaVersion = JavaVersion.toVersion(
-        providers.fileContents(layout.projectDirectory.file(".java-version")).asText.get())
+val javaVersion = JavaVersion.VERSION_1_8
 
 java {
     sourceCompatibility = javaVersion


### PR DESCRIPTION
We use random version for Java compile tasks. So, if gradle used JVM 17 then bytecode will require JVM 17. However, we don't need to set this requirement (we don't use any advanced features from a new JVM version, therefore we can stay on the same version with Gradle.